### PR TITLE
Keep empty script configuration

### DIFF
--- a/proguard-rules/script.pro
+++ b/proguard-rules/script.pro
@@ -44,6 +44,8 @@
 -keep,allowoptimization public class * extends com.cereal.sdk.Script {
     public <methods>;
 }
+-keep class * implements com.cereal.sdk.ScriptConfiguration
+
 # Keep the SDK signature intact
 -keep class com.cereal.sdk.** { *; }
 


### PR DESCRIPTION
Keep script configuration implementations, this solves an issue when scripts don't define configuration items.