### PR TITLE
Keep the java INSTANCE so that it can be used to get the object instance.

### DIFF
--- a/proguard-rules/script.pro
+++ b/proguard-rules/script.pro
@@ -64,3 +64,8 @@
 
 # Keep the enum class so that annotations are preserved.
 -keep enum * {}
+
+# Needed for the state modifiers objects.
+-keepclassmembers class * {
+    public static final *** INSTANCE;
+}


### PR DESCRIPTION
Keep the java INSTANCE so that it can be used to get the object instance of state modifiers.

Note: SDK update which includes the state modifiers will come soon.