### PR TITLE
Fix proguard issue with state modifier objectInstance not found.

### DIFF
--- a/proguard-rules/script.pro
+++ b/proguard-rules/script.pro
@@ -62,10 +62,11 @@
     @com.cereal.sdk.TaskConfigurationItem *;
 }
 
+# Keep all classes that implement com.cereal.sdk.statemodifier.StateModifier
+-keep class * implements com.cereal.sdk.statemodifier.StateModifier {
+    <init>(...);
+    *;
+}
+
 # Keep the enum class so that annotations are preserved.
 -keep enum * {}
-
-# Needed for the state modifiers objects.
--keepclassmembers class * {
-    public static final *** INSTANCE;
-}


### PR DESCRIPTION
Looks like the current solution to keep the object instance of the state modifiers doesn't work (anymore). This will simply prevents Proguard from obfuscating any statemodifier and therefor prevents important internal fields to get removed. We might need to check other (existing) scripts for correct working.