### PR TITLE
Automatically create a GitHub Release with the built JAR attached

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build
@@ -28,8 +31,17 @@ jobs:
       - name: Obfuscate
         run:
           ./gradlew scriptJar
+      - name: Rename jar with version
+        run: mv build/cereal/release.jar build/cereal/release-${{ github.ref_name }}.jar
       - name: Store script jar
         uses: actions/upload-artifact@v4
         with:
           name: script-${{ github.ref_name }}-release
-          path: build/cereal/release.jar
+          path: build/cereal/release-${{ github.ref_name }}.jar
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: build/cereal/release-${{ github.ref_name }}.jar
+          generate_release_notes: true

--- a/readme.md
+++ b/readme.md
@@ -35,9 +35,16 @@ git clone https://github.com/Your-Org/Script-Repo-Name.git
 First update the script version in `src/main/resources/manifest.json`
 
 #### Build binary using GitHub Actions
-Next, the easiest way to build the script binary is by creating a git tag. This will trigger GitHub Actions to build a jar and
-obfuscate it. This jar is uploaded as artifact and is therefore available in the [GitHub Actions Artifacts](https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts)
-section.
+Next, the easiest way to build the script binary is by creating a git tag. This will trigger GitHub Actions to build a jar,
+obfuscate it, and automatically create a GitHub Release with the jar attached as an artifact. You can find the release
+on the [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) page of
+your repository.
+
+To create a release:
+1. Update the version in `src/main/resources/manifest.json`
+2. Commit and push your changes
+3. Create and push a tag: `git tag v1.0.0 && git push origin v1.0.0`
+4. The workflow will automatically build and create a GitHub Release using the tag as the version, with `release-<version>.jar` attached
 
 #### Build binary manually
 If you are not using GitHub (Actions) or don't want to use this way of creating a jar you can execute
@@ -52,4 +59,4 @@ The jar can be found in the `build/cereal` folder.
 A GitHub actions configuration is included in this repository. It contains the following actions:
 
 * On each push to master tests will run.
-* When a tag is created an script release JAR is generated.
+* When a tag is created a script release JAR is generated and a GitHub Release is automatically created with the JAR attached.

--- a/readme.md
+++ b/readme.md
@@ -60,3 +60,9 @@ A GitHub actions configuration is included in this repository. It contains the f
 
 * On each push to master tests will run.
 * When a tag is created a script release JAR is generated and a GitHub Release is automatically created with the JAR attached.
+
+## Additional Resources
+For more detailed information on script development and publishing to the Cereal Marketplace:
+* [Cereal Developer Documentation](https://docs.cereal-automation.com/)
+* [Publishing Scripts Guide](https://docs.cereal-automation.com/developers/publishing/) - Learn how to publish your script to the Cereal Marketplace
+


### PR DESCRIPTION
This PR enhances the release workflow to automatically create GitHub Releases with the built script JAR artifact attached. The release version is derived from the git tag, providing clear version management and easier artifact distribution.