### PR TITLE
Add sdk_version to manifest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,18 @@ buildscript {
     }
 }
 
+val cerealSdkVersion = libs.versions.cereal.sdk.get()
+
+sourceSets.main {
+    resources.srcDirs("src/main/resources")
+}
+
+tasks.processResources {
+    filesMatching("manifest.json") {
+        filter { line -> line.replace("@cereal-sdk-version@", cerealSdkVersion) }
+    }
+}
+
 dependencies {
     implementation(libs.cereal.sdk)
     implementation(libs.cereal.licensing)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,10 +61,6 @@ buildscript {
 
 val cerealSdkVersion = libs.versions.cereal.sdk.get()
 
-sourceSets.main {
-    resources.srcDirs("src/main/resources")
-}
-
 tasks.processResources {
     filesMatching("manifest.json") {
         filter { line -> line.replace("@cereal-sdk-version@", cerealSdkVersion) }

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -2,6 +2,7 @@
   "package_name": "com.cereal.samplescript",
   "name": "SampleScript",
   "version_code": 1,
+  "sdk_version": "@cereal-sdk-version@",
   "script": "com.cereal.script.sample.SampleScript",
   "instructions": "Please make sure you already have an active account before using this script."
 }


### PR DESCRIPTION
## Add `sdk_version` to manifest

Adds `sdk_version` as a required field to the script manifest, automatically injected at build time from the version catalog.

### Changes

**`manifest.json`**
Added `sdk_version` field with a `@cereal-sdk-version@` placeholder token that is replaced during the build.

**`build.gradle.kts`**
Added a `processResources` filter that replaces the placeholder with the actual `cereal-sdk` version read from `libs.versions.toml`. This keeps the value DRY — the SDK version is declared once in the version catalog and flows into both the Gradle dependency and the manifest automatically.

### Why

Previously the manifest had no record of which SDK version the script was built against. This field enables the Cereal runtime and developer console to enforce compatibility and reject uploads that don't declare an SDK version.